### PR TITLE
슬래시 커맨드 숨기기

### DIFF
--- a/src/bot.py
+++ b/src/bot.py
@@ -55,7 +55,19 @@ class DiscordBot:
 
                 if message_content is not None:
                     print(f'[{self.TAG}] {name} executed {message_content}')
-                    await interaction.response.send_message(f"> {message_content}")
+                    try:
+                        await interaction.channel.send(f"> {message_content}")
+                        await interaction.response.send_message(
+                            "메세지 전송 성공",
+                            ephemeral=True
+                        )
+
+                    except Exception as e:
+                        print(e)
+                        await interaction.response.send_message(
+                            "메세지 전송 실패",
+                            ephemeral=True
+                        )
                 else:
                     await interaction.response.send_message(
                         f"> failed to fine {name} from csv file",


### PR DESCRIPTION
Close #3 

```
명령어 자체는 숨기고, 그 명령어를 실행한 결과로 나오는 메시지만 모두에게 보이게 하고 싶다면, Discord에서 슬래시 명령어에 대한 명령어 자동 완료 메시지나 실행 기록은 숨길 수 없지만, 명령어를 실행했을 때 다른 사용자에게 명령어 자체를 안 보이게 하면서 결과 메시지만 보이게 할 수 있습니다.

이 경우 명령어 실행 시 실제 채팅에 남는 것은 없고, 모두에게 보이는 응답만 전송하려면, 다음과 같은 방법을 사용할 수 있습니다.

예제 코드

import discord
from discord.ext import commands

intents = discord.Intents.default()
bot = commands.Bot(command_prefix="!", intents=intents)

@bot.event
async def on_ready():
    print(f"Logged in as {bot.user}")
    await bot.tree.sync()  # 슬래시 명령어 동기화

@bot.tree.command(name="announce", description="A command that announces a message to everyone")
async def announce(interaction: discord.Interaction, message: str):
    # 명령어 자체는 숨기고, 응답은 모두에게 표시
    await interaction.response.defer()  # 명령어 실행 기록 숨기기 (메시지 응답 없음)
    
    # 메시지 전송 (모두에게 보임)
    await interaction.channel.send(f"📢 {interaction.user.mention} says: {message}")

bot.run("YOUR_BOT_TOKEN")

설명

	•	interaction.response.defer() : 응답을 지연시킴으로써, 사용자가 명령어를 실행했을 때 보이는 명령어 자동 완료 메시지나 임시 메시지를 숨깁니다. 이 방법을 사용하면, 명령어 실행 후 아무것도 채팅창에 보이지 않게 할 수 있습니다.
	•	interaction.channel.send() : 결과 메시지를 명령어를 실행한 채널에 모든 사용자에게 보이도록 전송합니다.

작동 원리

	1.	명령어 /announce를 실행하면, 사용자가 입력한 명령어 실행 메시지는 모두 숨겨집니다.
	2.	대신, 명령어가 실행되면 입력한 메시지가 채널에 모든 사용자에게 보이는 일반 메시지로 전송됩니다.

이렇게 하면 명령어 자체는 숨겨지면서, 결과 메시지만 모든 사용자에게 보이도록 할 수 있습니다.
```